### PR TITLE
Replacing deprecated (on Python 3.8) time.clock() function by time.monotonic()

### DIFF
--- a/timelock.py
+++ b/timelock.py
@@ -112,17 +112,17 @@ def cmd_compute(args):
 
     chain = tl.chains[args.index]
 
-    start_time = time.clock()
+    start_time = time.monotonic()
     start_i = chain.i
 
     while not chain.unlock(1):
 
-        hashes_per_sec = (chain.i - start_i) / (time.clock() - start_time)
+        hashes_per_sec = (chain.i - start_i) / (time.monotonic() - start_time)
         est_time_to_finish = (chain.n - chain.i) / hashes_per_sec
 
         logging.info('chain #%d: %ds elapsed, %ds to go at %.4f Mhash/s, i = %d, midstate = %s' % (
                      args.index,
-                     time.clock() - start_time,
+                     time.monotonic() - start_time,
                      est_time_to_finish,
                      hashes_per_sec/1000000,
                      chain.i,
@@ -148,7 +148,7 @@ def cmd_lock(args):
 def cmd_unlock(args):
     tl = timelock.Timelock.from_json(json.loads(args.file.read()))
 
-    start_time = time.clock()
+    start_time = time.monotonic()
     chain_idx = 0
     sum_hashes = 0
 
@@ -164,7 +164,7 @@ def cmd_unlock(args):
                 chain_idx += 1
 
             else:
-                hashes_per_sec = sum_hashes / (time.clock() - start_time)
+                hashes_per_sec = sum_hashes / (time.monotonic() - start_time)
 
                 sum_hashes_left = ((tl.chains[chain_idx].n - tl.chains[chain_idx].i)
                                    + sum([chain.n for chain in tl.chains[chain_idx+1:]]))
@@ -173,7 +173,7 @@ def cmd_unlock(args):
 
                 logging.info('chain #%d: %ds elapsed, %ds to go at %.4f Mhash/s' % (
                              chain_idx,
-                             time.clock() - start_time,
+                             time.monotonic() - start_time,
                              est_time_to_finish,
                              hashes_per_sec/1000000,
                              ))

--- a/timelock/__init__.py
+++ b/timelock/__init__.py
@@ -121,7 +121,7 @@ class TimelockChain:
             import pdb; pdb.set_trace()
             raise ValueError("Can't unlock chain: midstate not available")
 
-        start_time = time.clock()
+        start_time = time.monotonic()
 
         if j is None:
             j = self.n
@@ -130,15 +130,15 @@ class TimelockChain:
             raise ValueError('j > self.n')
 
         max_m = 1
-        while self.i < j and time.clock() - start_time < t:
-            t0 = time.clock()
+        while self.i < j and time.monotonic() - start_time < t:
+            t0 = time.monotonic()
 
             m = min(j - self.i, max_m)
             # FIXME: need some kind of "fastest kernel" thing here
             self.midstate = self.algorithm.KERNELS[-1].run(self.midstate, m)
             self.i += m
 
-            if time.clock() - t0 < 0.025:
+            if time.monotonic() - t0 < 0.025:
                 max_m *= 2
 
         assert self.i <= self.n
@@ -311,9 +311,9 @@ class Timelock:
 
         Returns True if the timelock is now unlocked, False if otherwise
         """
-        start_time = time.clock()
+        start_time = time.monotonic()
 
-        while self.secret is None and time.clock() - start_time < t:
+        while self.secret is None and time.monotonic() - start_time < t:
 
             enum_chains = tuple(enumerate(self.chains))
 

--- a/timelock/kernel.py
+++ b/timelock/kernel.py
@@ -80,12 +80,12 @@ class Kernel:
 
         Returns list of hashes/second for each run.
         """
-        start_time = time.clock()
+        start_time = time.monotonic()
 
         def time_run(n):
-            start_time = time.clock()
+            start_time = time.monotonic()
             cls.run(b'\x00'*cls.ALGORITHM.NONCE_LENGTH, n)
-            return time.clock() - start_time
+            return time.monotonic() - start_time
 
         # We don't want individual runs to be too short, so first find how many
         # iterations we need for a run to take 0.1 seconds.


### PR DESCRIPTION
This gets timelock compiling and working again, avoiding errors similar to:

INFO:root:Benchmarking kernel 'python'
Traceback (most recent call last):
  File "./timelock.py", line 304, in <module>
    args.cmd_func(args)
  File "./timelock.py", line 58, in cmd_benchmark
    run_results[kernel] = kernel.benchmark(args.runtime, args.n)
  File "/home/igorhvr/idm/timelock/timelock/timelock/kernel.py", line 83, in benchmark
    start_time = time.clock()
AttributeError: module 'time' has no attribute 'clock'